### PR TITLE
removes parens from parameter of last playMusic()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ playMusic("Jazz"); // "Playing some Jazz"
 ```
 
 ```js
-const playMusic = (music) => "Playing some " + music;
+const playMusic = music => "Playing some " + music;
 playMusic("Jazz"); // "Playing some Jazz"
 ```
 


### PR DESCRIPTION
The last 2 playMusic functions are exactly the same, but I believe the last one should remove parens from the parameter to demonstrate that parens are optional with single-parameter arrow functions.